### PR TITLE
Fix NSF grant number and format bibliography titles

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -209,7 +209,7 @@
 }
 
 @article{boettiger2015docker,
-  title = {An introduction to Docker for reproducible research},
+  title = {An introduction to {Docker} for reproducible research},
   author = {Boettiger, Carl},
   journal = {ACM SIGOPS Operating Systems Review},
   volume = {49},
@@ -230,7 +230,7 @@
 }
 
 @misc{fastapi2024,
-  title = {FastAPI: Modern, fast (high-performance), web framework for building APIs with Python 3.6+ based on standard Python type hints},
+  title = {FastAPI: Modern, fast (high-performance), web framework for building APIs with {Python} 3.6+ based on standard {Python} type hints},
   author = {{FastAPI Contributors}},
   year = {2024},
   url = {https://fastapi.tiangolo.com/},
@@ -246,7 +246,7 @@
 }
 
 @misc{ollama2024,
-  title = {Ollama: Get up and running with Llama 3.2, Mistral, Gemma 2, and other large language models},
+  title = {Ollama: Get up and running with {Llama} 3.2, {Mistral}, {Gemma} 2, and other large language models},
   author = {{Ollama Team}},
   year = {2024},
   url = {https://ollama.com/},
@@ -284,7 +284,7 @@
 }
 
 @article{merkel2014docker,
-  title = {Docker: lightweight linux containers for consistent development and deployment},
+  title = {Docker: lightweight {Linux} containers for consistent development and deployment},
   author = {Merkel, Dirk},
   journal = {Linux Journal},
   volume = {2014},
@@ -310,7 +310,7 @@
 }
 
 @misc{haystack2026,
-  title = {Get Started (Haystack Documentation)},
+  title = {Get Started ({Haystack} Documentation)},
   author = {{deepset Haystack}},
   year = {2026},
   url = {https://docs.haystack.deepset.ai/docs/get-started},
@@ -342,7 +342,7 @@
 }
 
 @misc{neo4j2026graphrag,
-  title = {neo4j/neo4j-graphrag-python: Neo4j GraphRAG Package for Python},
+  title = {neo4j/neo4j-graphrag-python: Neo4j GraphRAG Package for {Python}},
   author = {{Neo4j}},
   year = {2026},
   url = {https://github.com/neo4j/neo4j-graphrag-python},

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -26,7 +26,7 @@ bibliography: paper.bib
 
 # Summary
 
-Large language models (LLMs) are widely used in research workflows but struggle with hallucinations, short context windows, and weak reproducibility in literature reviews [@Ji2023; @Huang2025]. Nexarag is a modular, open‑source platform that lets researchers curate, visualize, and share custom knowledge graphs (KGs) from academic sources stored in Neo4j [@neo4j2024database]. Through native support for the Model Context Protocol (MCP), any MCP‑compatible LLM can access these curated KGs for controllable, reproducible context injection [@anthropic2024mcp; @mcp2024github]—including fully private, air‑gapped deployments via containers [@boettiger2015docker]—so teams can explore literature more deeply and transparently. Nexarag provides interactive graph/semantic visualizations using Cytoscape.js and D3 [@franz2023cytoscape; @bostock2011d3].
+Large language models (LLMs) are widely used in research workflows but struggle with hallucinations, short context windows, and weak reproducibility in literature reviews [@Ji2023; @Huang2025]. Nexarag is a modular, open‑source platform that lets researchers curate, visualize, and share custom knowledge graphs (KGs) from academic sources stored in Neo4j [@neo4j2024database]. Through native support for the Model Context Protocol (MCP), any MCP‑compatible LLM can access these curated KGs for controllable, reproducible context injection [@anthropic2024mcp; @mcp2024github]—including fully private, air‑gapped deployments via containers [@boettiger2015docker]—so research teams can explore relevant literature more deeply and transparently. Nexarag provides interactive graph/semantic visualizations using Cytoscape.js and D3 [@franz2023cytoscape; @bostock2011d3].
 
 
 # Statement of need

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -80,6 +80,6 @@ All AI-generated material was explicitly reviewed by at least one author, and al
 
 # Acknowledgements
 
-We acknowledge the open‑source ecosystems behind Neo4j, Cytoscape.js, D3.js, RabbitMQ, FastAPI, Ollama, and the Model Context Protocol, as well as contributors and users who provided feedback during development. This research was supported in part by the NSF under Grant 221235.
+We acknowledge the open‑source ecosystems behind Neo4j, Cytoscape.js, D3.js, RabbitMQ, FastAPI, Ollama, and the Model Context Protocol, as well as contributors and users who provided feedback during development. This research was supported in part by the NSF under Grant 2212325.
 
 # References


### PR DESCRIPTION
This pull request makes minor improvements to the `paper.bib` bibliography and the `paper.md` manuscript, focusing primarily on enhanced formatting for consistency and clarity, as well as a correction to the grant number in the acknowledgements.

Bibliography formatting improvements:

* Updated several bibliography entry titles in `paper.bib` to use curly braces around software and technology names (e.g., `{Docker}`, `{Python}`, `{Llama}`, `{Mistral}`, `{Gemma}`, `{Linux}`, `{Haystack}`) for proper capitalization and formatting in the rendered bibliography.

Manuscript content and metadata corrections:

* Clarified the summary in `paper.md` to specify "research teams" instead of just "teams" for greater precision.
* Corrected the NSF grant number in the acknowledgements section of `paper.md` from "221235" to "2212325".